### PR TITLE
Fix CI package installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,11 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
+          registry: https://npm.pkg.github.com
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          registry-url: 'https://registry.npmjs.org'
 
-      - run: npm ci
+      - run: npm ci --registry https://registry.npmjs.org
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          registry: https://npm.pkg.github.com
+          registry-url: https://npm.pkg.github.com
 
       - run: npm ci
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,13 @@ jobs:
           node-version: 15
           registry-url: 'https://registry.npmjs.org'
 
+      - run: npm ci
+
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
           name: npm-error-log
           path: /home/runner/.npm/_logs
-
-      - run: npm ci
 
       - run: npx commitlint --from HEAD~1 --to HEAD --verbose
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,12 @@ jobs:
           node-version: 15
           registry-url: 'https://registry.npmjs.org'
 
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: npm-error-log
+          path: /home/runner/.npm/_logs
+
       - run: npm ci
 
       - run: npx commitlint --from HEAD~1 --to HEAD --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,6 @@ jobs:
           # Provide a "password" to GPR so that we can pull our packages.
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-artifact@v2
-        if: ${{ always() }}
-        with:
-          name: npm-error-log
-          path: /home/runner/.npm/_logs
-
       - run: npx commitlint --from HEAD~1 --to HEAD --verbose
 
   eslint:
@@ -46,7 +40,16 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          registry-url: 'https://registry.npmjs.org'
+          # We must indicate the Github Package Registry, as our config packages
+          # are there (and also NPM). Frustratingly, NPM prefers the GPR over
+          # NPM - even when we indicate that we want to pull from NPM instead of
+          # the GPR.
+          registry-url: https://npm.pkg.github.com
+
+      - run: npm ci
+        env:
+          # Provide a "password" to GPR so that we can pull our packages.
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: npm ci
 
@@ -62,8 +65,15 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          registry-url: 'https://registry.npmjs.org'
+          # We must indicate the Github Package Registry, as our config packages
+          # are there (and also NPM). Frustratingly, NPM prefers the GPR over
+          # NPM - even when we indicate that we want to pull from NPM instead of
+          # the GPR.
+          registry-url: https://npm.pkg.github.com
 
       - run: npm ci
+        env:
+          # Provide a "password" to GPR so that we can pull our packages.
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,15 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          # registry-url: https://npm.pkg.github.com
-          registry-url: https://registry.npmjs.org
+          # We must indicate the Github Package Registry, as our config packages
+          # are there (and also NPM). Frustratingly, NPM prefers the GPR over
+          # NPM - even when we indicate that we want to pull from NPM instead of
+          # the GPR.
+          registry-url: https://npm.pkg.github.com
 
       - run: npm ci
         env:
+          # Provide a "password" to GPR so that we can pull our packages.
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches-ignore: [ master, main ]
 
-permissions:
-  packages: read
-
 jobs:
   commitlint:
     name: Lint commits

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - run: npm ci
-        # env:
-        #   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,12 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          registry-url: https://npm.pkg.github.com
+          # registry-url: https://npm.pkg.github.com
+          registry-url: https://registry.npmjs.org
 
       - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # env:
+        #   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches-ignore: [ master, main ]
 
+permissions:
+  packages: read
+
 jobs:
   commitlint:
     name: Lint commits
@@ -18,7 +21,7 @@ jobs:
         with:
           node-version: 15
 
-      - run: npm ci --registry https://registry.npmjs.org
+      - run: npm ci
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
 
@@ -32,6 +33,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
 
@@ -47,6 +49,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@joebobmiles:registry=https://registry.npmjs.org

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@joebobmiles:registry=https://registry.npmjs.org


### PR DESCRIPTION
Annoyingly, the CI has been failing because it's been trying to install a package from the GitHub registry. Which you need to authenticate with in order to download from. (But only when you are in a GitHub Actions workflow?) This is in spite of the fact that the exact same versions of the package are available on both the NPM registry and the GitHub registry.

After some trial and error, I learned that even if you tell NPM to prefer the NPM registry, it will still pull from the GitHub repository. (At least if you are in GitHub Actions. I was unable to reproduce this issue outside of a live GitHub Actions workflow.)