### PR TITLE
Implement our own, internal json-diff operation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,6 @@ jobs:
           node-version: 15
 
       - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ always() }}
-        with:
-          name: npm-install-log
-          path: /home/runner/.npm/_logs
 
       - run: npm run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: 15
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - run: npm run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: npm-install-log
+          path: /home/runner/.npm/_logs
+
       - run: npm run build
 
       - run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
         with:
           name: npm-install-log
           path: /home/runner/.npm/_logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,11 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
+          registry-url: https://npm.pkg.github.com/
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - run: npm run build
 
@@ -26,3 +29,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: npm-install-log-test
+          path: /home/runner/.npm/_logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,16 +17,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          # We must indicate the Github Package Registry, as our config packages
-          # are there (and also NPM). Frustratingly, NPM prefers the GPR over
-          # NPM - even when we indicate that we want to pull from NPM instead of
-          # the GPR.
-          registry-url: https://npm.pkg.github.com
 
       - run: npm ci
-        env:
-          # Provide a "password" to GPR so that we can pull our packages.
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - run: npm run build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: npm-install-log
+          path: /home/runner/.npm/_logs
+
       - run: npx commitlint --from HEAD~1 --to HEAD --verbose
 
   eslint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: 15
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - run: npx commitlint --from HEAD~1 --to HEAD --verbose
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      - uses: actions/upload-artifact@v2
-        if: ${{ always() }}
-        with:
-          name: npm-install-log
-          path: /home/runner/.npm/_logs
-
       - run: npx commitlint --from HEAD~1 --to HEAD --verbose
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: npm-install-log-commitlint
+          path: /home/runner/.npm/_logs
 
   eslint:
     name: Lint code
@@ -41,12 +41,19 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
+          registry-url: https://npm.pkg.github.com/
 
       - run: npm ci
-
-      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - run: npx eslint .
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: npm-install-log-eslint
+          path: /home/runner/.npm/_logs
 
   test:
     name: Run tests
@@ -58,7 +65,16 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
+          registry-url: https://npm.pkg.github.com/
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - run: npm run test
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: npm-install-log-test
+          path: /home/runner/.npm/_logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 15
+          node-version: 16
 
       - run: npm install -g npm@latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          registry: https://registry.npmjs.org/
+          registry-url: https://registry.npmjs.org/
 
       - run: npm ci
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          # We must indicate the Github Package Registry, as our config packages
-          # are there (and also NPM). Frustratingly, NPM prefers the GPR over
-          # NPM - even when we indicate that we want to pull from NPM instead of
-          # the GPR.
-          registry-url: https://npm.pkg.github.com
 
       - run: npm ci
-        env:
-          # Provide a "password" to GPR so that we can pull our packages.
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - run: npx commitlint --from HEAD~1 --to HEAD --verbose
 
@@ -40,16 +32,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          # We must indicate the Github Package Registry, as our config packages
-          # are there (and also NPM). Frustratingly, NPM prefers the GPR over
-          # NPM - even when we indicate that we want to pull from NPM instead of
-          # the GPR.
-          registry-url: https://npm.pkg.github.com
 
       - run: npm ci
-        env:
-          # Provide a "password" to GPR so that we can pull our packages.
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - run: npm ci
 
@@ -65,15 +49,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          # We must indicate the Github Package Registry, as our config packages
-          # are there (and also NPM). Frustratingly, NPM prefers the GPR over
-          # NPM - even when we indicate that we want to pull from NPM instead of
-          # the GPR.
-          registry-url: https://npm.pkg.github.com
 
       - run: npm ci
-        env:
-          # Provide a "password" to GPR so that we can pull our packages.
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           node-version: 15
 
+      - run: npm install -g npm@latest
+
       - run: npm ci --scope=@joebobmiles --registry=https://registry.npmjs.org
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
+          registry: https://registry.npmjs.org/
 
       - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
         with:
           name: npm-install-log
           path: /home/runner/.npm/_logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
-          registry-url: https://registry.npmjs.org/
 
-      - run: npm ci
+      - run: npm ci --scope=@joebobmiles --registry=https://registry.npmjs.org
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 15
+          registry-url: https://npm.pkg.github.com/
 
       - run: npm ci
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,11 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 15
 
-      - run: npm install -g npm@latest
-
-      - run: npm ci --scope=@joebobmiles --registry=https://registry.npmjs.org
+      - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
+registry=https://registry.npmjs.org/
 @joebobmiles:registry=https://registry.npmjs.org/
+@joebobmiles:always-auth=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@joebobmiles:registry=https://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-registry=https://registry.npmjs.org/
-@joebobmiles:registry=https://registry.npmjs.org/
-@joebobmiles:always-auth=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@rollup/plugin-typescript": "^8.2.1",
         "@semantic-release/git": "^9.0.0",
         "@types/jest": "^26.0.24",
-        "@types/json-diff": "^0.5.1",
         "eslint": "^7.30.0",
         "husky": "^7.0.1",
         "jest": "^27.0.6",
@@ -1923,12 +1922,6 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
-    },
-    "node_modules/@types/json-diff": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@types/json-diff/-/json-diff-0.5.1.tgz",
-      "integrity": "sha512-/XJ7OPKk+fJCJF93CCA1l2EojXd+dNysFNJN42igT96Xur0tmGQx6U+tm5boDVvgwU7M8ADaWaRuJZx98v2a9g==",
-      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.8",
@@ -13032,12 +13025,6 @@
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
       }
-    },
-    "@types/json-diff": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@types/json-diff/-/json-diff-0.5.1.tgz",
-      "integrity": "sha512-/XJ7OPKk+fJCJF93CCA1l2EojXd+dNysFNJN42igT96Xur0tmGQx6U+tm5boDVvgwU7M8ADaWaRuJZx98v2a9g==",
-      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "1.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
-        "json-diff": "^0.5.4",
         "yjs": "^13.5.11",
         "zustand": "^3.5.5"
       },
@@ -1540,82 +1539,6 @@
         "rollup": "^1.20.0||^2.0.0"
       }
     },
-    "node_modules/@semantic-release/changelog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-5.0.1.tgz",
-      "integrity": "sha512-unvqHo5jk4dvAf2nZ3aw4imrlwQ2I50eVVvq9D47Qc3R+keNqepx1vDYwkjF8guFXnOYaYcR28yrZWno1hFbiw==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "commondir": "^1.0.1",
-        "estree-walker": "^2.0.1",
-        "glob": "^7.1.6",
-        "is-reference": "^1.2.1",
-        "magic-string": "^0.25.7",
-        "resolve": "^1.17.0"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.38.3"
-      }
-    },
-    "node_modules/@rollup/plugin-node-resolve": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz",
-      "integrity": "sha512-41X411HJ3oikIDivT5OKe9EZ6ud6DXudtfNrGbC4nniaxx2esiWjkLOzgnZsWq1IM8YIeL2rzRGLZLBjlhnZtQ==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "@types/resolve": "1.17.1",
-        "builtin-modules": "^3.1.0",
-        "deepmerge": "^4.2.2",
-        "is-module": "^1.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.42.0"
-      }
-    },
-    "node_modules/@rollup/plugin-typescript": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.1.tgz",
-      "integrity": "sha512-Qd2E1pleDR4bwyFxqbjt4eJf+wB0UKVMLc7/BAFDGVdAXQMCsD4DUv5/7/ww47BZCYxWtJqe1Lo0KVNswBJlRw==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "resolve": "^1.17.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.14.0",
-        "tslib": "*",
-        "typescript": ">=3.7.0"
-      }
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
     "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
@@ -2804,17 +2727,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cli-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
-      "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
-      "dependencies": {
-        "es5-ext": "0.8.x"
-      },
-      "engines": {
-        "node": ">=0.1.103"
-      }
-    },
     "node_modules/cli-table": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
@@ -2898,12 +2810,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -3291,17 +3197,6 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/difflib": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
-      "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
-      "dependencies": {
-        "heap": ">= 0.2.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -3357,17 +3252,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dreamopt": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
-      "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
-      "dependencies": {
-        "wordwrap": ">=0.0.2"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/duplexer2": {
@@ -3491,14 +3375,6 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es5-ext": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
-      "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs=",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/escalade": {
@@ -3886,12 +3762,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -4410,11 +4280,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/heap": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
-      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
     "node_modules/hook-std": {
       "version": "2.0.0",
@@ -5925,22 +5790,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/json-diff": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.5.4.tgz",
-      "integrity": "sha512-q5Xmx9QXNOzOzIlMoYtLrLiu4Jl/Ce2bn0CNcv54PhyH89CI4GWlGVDye8ei2Ijt9R3U+vsWPsXpLUNob8bs8Q==",
-      "dependencies": {
-        "cli-color": "~0.1.6",
-        "difflib": "~0.2.1",
-        "dreamopt": "~0.6.0"
-      },
-      "bin": {
-        "json-diff": "bin/json-diff.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -11518,7 +11367,8 @@
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -12854,56 +12704,6 @@
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
         "picomatch": "^2.2.2"
-      }
-    },
-    "@semantic-release/changelog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-5.0.1.tgz",
-      "integrity": "sha512-unvqHo5jk4dvAf2nZ3aw4imrlwQ2I50eVVvq9D47Qc3R+keNqepx1vDYwkjF8guFXnOYaYcR28yrZWno1hFbiw==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "commondir": "^1.0.1",
-        "estree-walker": "^2.0.1",
-        "glob": "^7.1.6",
-        "is-reference": "^1.2.1",
-        "magic-string": "^0.25.7",
-        "resolve": "^1.17.0"
-      }
-    },
-    "@rollup/plugin-node-resolve": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.0.tgz",
-      "integrity": "sha512-41X411HJ3oikIDivT5OKe9EZ6ud6DXudtfNrGbC4nniaxx2esiWjkLOzgnZsWq1IM8YIeL2rzRGLZLBjlhnZtQ==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "@types/resolve": "1.17.1",
-        "builtin-modules": "^3.1.0",
-        "deepmerge": "^4.2.2",
-        "is-module": "^1.0.0",
-        "resolve": "^1.19.0"
-      }
-    },
-    "@rollup/plugin-typescript": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.1.tgz",
-      "integrity": "sha512-Qd2E1pleDR4bwyFxqbjt4eJf+wB0UKVMLc7/BAFDGVdAXQMCsD4DUv5/7/ww47BZCYxWtJqe1Lo0KVNswBJlRw==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "resolve": "^1.17.0"
-      }
-    },
-    "@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
       },
       "dependencies": {
         "estree-walker": {
@@ -13822,14 +13622,6 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
-    "cli-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
-      "integrity": "sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=",
-      "requires": {
-        "es5-ext": "0.8.x"
-      }
-    },
     "cli-table": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
@@ -13897,12 +13689,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -14207,14 +13993,6 @@
       "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
       "dev": true
     },
-    "difflib": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
-      "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
-      "requires": {
-        "heap": ">= 0.2.0"
-      }
-    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -14257,14 +14035,6 @@
       "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
-      }
-    },
-    "dreamopt": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
-      "integrity": "sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=",
-      "requires": {
-        "wordwrap": ">=0.0.2"
       }
     },
     "duplexer2": {
@@ -14364,11 +14134,6 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "es5-ext": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
-      "integrity": "sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs="
     },
     "escalade": {
       "version": "3.1.1",
@@ -14638,12 +14403,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
       "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-      "dev": true
-    },
-    "estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
     "esutils": {
@@ -15045,11 +14804,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
-    },
-    "heap": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
-      "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
     "hook-std": {
       "version": "2.0.0",
@@ -16195,16 +15949,6 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
-    },
-    "json-diff": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.5.4.tgz",
-      "integrity": "sha512-q5Xmx9QXNOzOzIlMoYtLrLiu4Jl/Ce2bn0CNcv54PhyH89CI4GWlGVDye8ei2Ijt9R3U+vsWPsXpLUNob8bs8Q==",
-      "requires": {
-        "cli-color": "~0.1.6",
-        "difflib": "~0.2.1",
-        "dreamopt": "~0.6.0"
-      }
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -20214,7 +19958,8 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "json-diff": "^0.5.4",
     "yjs": "^13.5.11",
     "zustand": "^3.5.5"
   },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@rollup/plugin-typescript": "^8.2.1",
     "@semantic-release/git": "^9.0.0",
     "@types/jest": "^26.0.24",
-    "@types/json-diff": "^0.5.1",
     "eslint": "^7.30.0",
     "husky": "^7.0.1",
     "jest": "^27.0.6",

--- a/src/diff.spec.ts
+++ b/src/diff.spec.ts
@@ -1,0 +1,81 @@
+import { diff, } from "./diff";
+
+describe("diff", () =>
+{
+  describe("When passed scalar values", () =>
+  {
+    it("Returns undefined for two identical numbers.", () =>
+    {
+      expect(diff(1, 1)).toBeUndefined();
+    });
+
+    it("Returns undefined for two identical strings.", () =>
+    {
+      expect(diff("hello", "hello")).toBeUndefined();
+    });
+
+    it(
+      "Returns { __old: <old>, __new: <new> } for different values.",
+      () =>
+      {
+        expect(diff(1, 2)).toEqual({
+          "__old": 1,
+          "__new": 2,
+        });
+      }
+    );
+  });
+
+  describe("When passed objects", () =>
+  {
+    it("Returns undefined for two objects with identical contents.", () =>
+    {
+      expect(diff({ "foo": 1, }, { "foo": 1, })).toBeUndefined();
+    });
+
+    it("Returns undefined for two objects with identical hierarchies.", () =>
+    {
+      expect(diff(
+        { "foo": { "bar": 1, }, },
+        { "foo": { "bar": 1, }, }
+      )).toBeUndefined();
+    });
+
+    it("Returns { <key>__deleted: <old> } when b is missing <key>.", () =>
+    {
+      expect(diff(
+        { "foo": 1, },
+        { }
+      )).toEqual({
+        "foo__deleted": 1,
+      });
+    });
+
+    it("Returns { <key>__added: <new> } when a is missing <key>.", () =>
+    {
+      expect(diff(
+        { },
+        { "foo": 1, }
+      )).toEqual({
+        "foo__added": 1,
+      });
+    });
+
+    it(
+      "Returns { <key>: { __old: <old>, __new: <new> } } when a and b have "
+      +"different <key> values.",
+      () =>
+      {
+        expect(diff(
+          { "foo": 1, },
+          { "foo": 2, }
+        )).toEqual({
+          "foo": {
+            "__old": 1,
+            "__new": 2,
+          },
+        });
+      }
+    );
+  });
+});

--- a/src/diff.spec.ts
+++ b/src/diff.spec.ts
@@ -124,6 +124,24 @@ describe("diff", () =>
     );
 
     it(
+      "Returns [ ..., [ '-', <removed> ], [ '+', <added> ], ... ] for replaced "
+      +"values.",
+      () =>
+      {
+        expect(diff([ 1 ], [ 2 ])).toEqual([ [ "-", 1 ], [ "+", 2 ] ]);
+      }
+    );
+
+    it("Does not forget additions at the end of b.", () =>
+    {
+      expect(diff([ 1 ], [ 2, 3 ])).toEqual([
+        [ "-", 1 ],
+        [ "+", 2 ],
+        [ "+", 3 ]
+      ]);
+    });
+
+    it(
       "Returns [ ..., [ '+', <added> ] ] when a is missing a value.",
       () =>
       {

--- a/src/diff.spec.ts
+++ b/src/diff.spec.ts
@@ -135,4 +135,47 @@ describe("diff", () =>
       }
     );
   });
+
+  describe("When passed arrays with nested objects", () =>
+  {
+    it("Returns undefined for arrays of identical contents.", () =>
+    {
+      expect(diff([ { "foo": 1, } ], [ { "foo": 1, } ])).toBeUndefined();
+    });
+
+    it(
+      "Returns [ ..., [ '-', <removed> ], ... ] when b is missing an item.",
+      () =>
+      {
+        expect(diff([ { "foo": 1, }, { "bar": 2, } ], [ { "foo": 1, } ]))
+          .toEqual([
+            [ " ", { "foo": 1, } ],
+            [ "-", { "bar": 2, } ]
+          ]);
+      }
+    );
+
+    it(
+      "Returns [ ..., [ '+', <added> ], ... ] when a is missing an item.",
+      () =>
+      {
+        expect(diff([ { "foo": 1, } ], [ { "foo": 1, }, { "bar": 2, } ]))
+          .toEqual([
+            [ " ", { "foo": 1, } ],
+            [ "+", { "bar": 2, } ]
+          ]);
+      }
+    );
+
+    it(
+      "Returns [ ..., [ '~', <diff> ], ... ] when the item is modified.",
+      () =>
+      {
+        expect(diff([ { "foo": 1, } ], [ { "foo": 2, } ]))
+          .toEqual([
+            [ "~", { "foo": { "__old": 1, "__new": 2, }, } ]
+          ]);
+      }
+    );
+  });
 });

--- a/src/diff.spec.ts
+++ b/src/diff.spec.ts
@@ -77,5 +77,18 @@ describe("diff", () =>
         });
       }
     );
+
+    it("Only returns fields that have changed.", () =>
+    {
+      expect(diff(
+        { "foo": 1, "bar": 2, },
+        { "foo": 1, "bar": 3, }
+      )).toEqual({
+        "bar": {
+          "__old": 2,
+          "__new": 3,
+        },
+      });
+    });
   });
 });

--- a/src/diff.spec.ts
+++ b/src/diff.spec.ts
@@ -91,4 +91,48 @@ describe("diff", () =>
       });
     });
   });
+
+  describe("When passed arrays of scalar values", () =>
+  {
+    it("Returns undefined for arrays with identical contents.", () =>
+    {
+      expect(diff([ 1, 2, 3 ], [ 1, 2, 3 ])).toBeUndefined();
+    });
+
+    it(
+      "Returns [ ..., [ '-', <removed> ], ... ] when b is missing a value.",
+      () =>
+      {
+        expect(diff([ 1, 2, 3 ], [ 1, 2 ])).toEqual([
+          [ " ", 1 ],
+          [ " ", 2 ],
+          [ "-", 3 ]
+        ]);
+      }
+    );
+
+    it(
+      "Returns [ ..., [ '+', <added> ], ... ] when a is missing a value.",
+      () =>
+      {
+        expect(diff([ 1, 3 ], [ 1, 2, 3 ])).toEqual([
+          [ " ", 1 ],
+          [ "+", 2 ],
+          [ " ", 3 ]
+        ]);
+      }
+    );
+
+    it(
+      "Returns [ ..., [ '+', <added> ] ] when a is missing a value.",
+      () =>
+      {
+        expect(diff([ 1, 2 ], [ 1, 2, 3 ])).toEqual([
+          [ " ", 1 ],
+          [ " ", 2 ],
+          [ "+", 3 ]
+        ]);
+      }
+    );
+  });
 });

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -3,7 +3,46 @@ export const diff = (a: any, b: any): any =>
 {
   if (!Object.is(a, b))
   {
-    if (a instanceof Object && b instanceof Object)
+    if (a instanceof Array && b instanceof Array)
+    {
+      const result: any[] = [];
+
+      if (a.length === b.length)
+      {
+        if (a.every((value, index) =>
+          value === b[index]))
+          return undefined;
+      }
+
+      a.forEach((value, index) =>
+      {
+        if (b[index] === undefined)
+          result.push([ "-", value ]);
+
+        else if (b[index] !== value && b[index + 1] === value)
+          result.push([ "+", b[index] ], [ " ", value ]);
+
+        else if (b[index] !== value)
+          result.push([ "+", b[index] ]);
+
+        else
+          result.push([ " ", value ]);
+      });
+
+      if (result.length < a.length)
+      {
+        a.slice(b.length).forEach((value) =>
+          result.push([ "-", value ]));
+      }
+      else if (result.length < b.length)
+      {
+        b.slice(a.length).forEach((value) =>
+          result.push([ "+", value ]));
+      }
+
+      return result;
+    }
+    else if (a instanceof Object && b instanceof Object)
     {
       const result: any = {};
 

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -5,6 +5,7 @@ export const diff = (a: any, b: any): any =>
   {
     if (a instanceof Array && b instanceof Array)
     {
+
       const result: any[] = [];
 
       if (a.length === b.length)
@@ -13,6 +14,8 @@ export const diff = (a: any, b: any): any =>
           diff(value, b[index]) === undefined))
           return undefined;
       }
+
+      let finalIndices = 0;
 
       a.forEach((value, index) =>
       {
@@ -32,21 +35,31 @@ export const diff = (a: any, b: any): any =>
 
           else
             result.push([ " ", value ]);
+
+          finalIndices++;
         }
 
         else if (value !== b[index] && value === b[index+1])
+        {
           result.push([ "+", b[index] ], [ " ", value ]);
+          finalIndices += 2;
+        }
+
+        else if (value !== b[index] && value !== b[index+1])
+        {
+          result.push([ "-", value ], [ "+", b[index] ]);
+          finalIndices++;
+        }
 
         else
+        {
           result.push([ " ", value ]);
+          finalIndices++;
+        }
+
       });
 
-      if (result.length < a.length)
-      {
-        a.slice(b.length).forEach((value) =>
-          result.push([ "-", value ]));
-      }
-      else if (result.length < b.length)
+      if (finalIndices < b.length)
       {
         b.slice(a.length).forEach((value) =>
           result.push([ "+", value ]));

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,0 +1,51 @@
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const diff = (a: any, b: any): any =>
+{
+  if (!Object.is(a, b))
+  {
+    if (a instanceof Object && b instanceof Object)
+    {
+      const result: any = {};
+
+      Object.entries(b).forEach(([ property, value ]) =>
+      {
+        if (a[property] === undefined)
+          result[`${property}__added`] = value;
+
+        else if (a[property] instanceof Object && value instanceof Object)
+        {
+          const d = diff(a[property], value);
+
+          if (d !== undefined)
+            result[property] = d;
+        }
+
+        else if (a[property] !== value)
+        {
+          result[property] =
+          {
+            "__old": a[property],
+            "__new": value,
+          };
+        }
+      });
+
+      Object.entries(a).forEach(([ property, value ]) =>
+      {
+        if (b[property] === undefined)
+          result[`${property}__deleted`] = value;
+      });
+
+      return Object.entries(result).length === 0 ? undefined : result;
+    }
+    else if (a !== b)
+    {
+      return {
+        "__old": a,
+        "__new": b,
+      };
+    }
+  }
+  else
+    return undefined;
+};

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -10,7 +10,7 @@ export const diff = (a: any, b: any): any =>
       if (a.length === b.length)
       {
         if (a.every((value, index) =>
-          value === b[index]))
+          diff(value, b[index]) === undefined))
           return undefined;
       }
 
@@ -19,11 +19,23 @@ export const diff = (a: any, b: any): any =>
         if (b[index] === undefined)
           result.push([ "-", value ]);
 
-        else if (b[index] !== value && b[index + 1] === value)
-          result.push([ "+", b[index] ], [ " ", value ]);
+        else if (value instanceof Object && b[index] instanceof Object)
+        {
+          const currentDiff = diff(value, b[index]);
+          const nextDiff = diff(value, b[index+1]);
 
-        else if (b[index] !== value)
-          result.push([ "+", b[index] ]);
+          if (currentDiff !== undefined && nextDiff === undefined)
+            result.push([ "+", b[index] ], [ " ", value ]);
+
+          else if (currentDiff !== undefined)
+            result.push([ "~", currentDiff ]);
+
+          else
+            result.push([ " ", value ]);
+        }
+
+        else if (value !== b[index] && value === b[index+1])
+          result.push([ "+", b[index] ], [ " ", value ]);
 
         else
           result.push([ " ", value ]);

--- a/src/patching.ts
+++ b/src/patching.ts
@@ -226,7 +226,49 @@ export const patchStore = <S extends State>(
     if (changes.length === 0)
       return oldState;
 
-    else
+    else if (oldState instanceof Array)
+    {
+      const p: any = changes
+        .sort(([ , indexA ], [ , indexB ]) =>
+          Math.sign((indexA as number) - (indexB as number)))
+        .reduce(
+          (state, [ type, index, value ]) =>
+          {
+            switch (type)
+            {
+            case "add":
+            case "update":
+            case "none":
+            {
+              return [
+                ...state,
+                value
+              ];
+            }
+
+            case "pending":
+            {
+              return [
+                ...state,
+                patch(
+                  oldState[index as number],
+                  newState[index as number]
+                )
+              ];
+            }
+
+            case "delete":
+            default:
+              return state;
+            }
+          },
+          [] as any[]
+        );
+
+      return p;
+    }
+
+    else if (oldState instanceof Object)
     {
       const p: any = changes.reduce(
         (state, [ type, property, value ]) =>

--- a/src/patching.ts
+++ b/src/patching.ts
@@ -1,5 +1,5 @@
 import * as Y from "yjs";
-import { diff, } from "json-diff";
+import { diff, } from "./diff";
 import { arrayToYArray, objectToYMap, } from "./mapping";
 import { State, StoreApi, } from "zustand/vanilla";
 


### PR DESCRIPTION
The json-diff library we depend on to find differences between JSON objects was great but is too old to be properly bundled for use in contemporary JavaScript projects. I've now reimplemented the one function we use from that library and integrated it with the rest of our codebase.