### PR TITLE
Fix inserts into arrays throwing type errors (#20)

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -453,4 +453,121 @@ describe("Yjs middleware (vanilla)", () =>
 
     expect(api.getState().count).toBe(12);
   });
+
+  describe("When adding consecutive entries into arrays", () =>
+  {
+    it("Does not throw when inserting multiple scalars into arrays.", () =>
+    {
+      type Store =
+      {
+        numbers: number[],
+        addNumber: (n: number) => void,
+      };
+
+      const doc = new Y.Doc();
+
+      const api =
+        create<Store>(yjs(
+          doc,
+          "hello",
+          (set) =>
+            ({
+              "numbers": [],
+              "addNumber": (n) =>
+                set((state) =>
+                  ({
+                    "numbers": [
+                      ...state.numbers,
+                      n
+                    ],
+                  })),
+            })
+        ));
+
+      expect(api.getState().numbers).toEqual([]);
+
+      expect(() =>
+      {
+        api.getState().addNumber(0);
+        api.getState().addNumber(1);
+      }).not.toThrow();
+    });
+
+    it("Does not throw when inserting multiple arrays into arrays.", () =>
+    {
+      type Store =
+      {
+        arrays: Array<any>[],
+        addArray: (array: any[]) => void,
+      };
+
+      const doc = new Y.Doc();
+
+      const api =
+        create<Store>(yjs(
+          doc,
+          "hello",
+          (set) =>
+            ({
+              "arrays": [],
+              "addArray": (array) =>
+                set((state) =>
+                  ({
+                    "arrays": [
+                      ...state.arrays,
+                      array
+                    ],
+                  })),
+            })
+        ));
+
+      expect(api.getState().arrays).toEqual([]);
+
+      expect(() =>
+      {
+        api.getState().addArray([ 1, 2, 3, 4 ]);
+        api.getState().addArray([ "foo", "bar", "baz" ]);
+      }).not.toThrow();
+    });
+
+    it("Does not throw when inserting multiple maps into arrays.", () =>
+    {
+      type Store =
+      {
+        users: { name: string, status: "online" | "offline" }[],
+        addUser: (name: string, status: "online" | "offline") => void,
+      };
+
+      const doc = new Y.Doc();
+
+      const api =
+        create<Store>(yjs(
+          doc,
+          "hello",
+          (set) =>
+            ({
+              "users": [],
+              "addUser": (name, status) =>
+                set((state) =>
+                  ({
+                    "users": [
+                      ...state.users,
+                      {
+                        "name": name,
+                        "status": status,
+                      }
+                    ],
+                  })),
+            })
+        ));
+
+      expect(api.getState().users).toEqual([]);
+
+      expect(() =>
+      {
+        api.getState().addUser("alice", "offline");
+        api.getState().addUser("bob", "offline");
+      }).not.toThrow();
+    });
+  });
 });

--- a/src/patching.ts
+++ b/src/patching.ts
@@ -137,29 +137,15 @@ export const patchSharedType = (
         {
           const index = property as number;
 
-          const left = sharedType.slice(0, index);
-          const right = sharedType.slice(index+1);
-
-          sharedType.delete(0, sharedType.length);
+          if (type === "update")
+            sharedType.delete(index);
 
           if (value instanceof Array)
-          {
-            sharedType.insert(0, [
-              ...left,
-              arrayToYArray(value),
-              ...right
-            ]);
-          }
+            sharedType.insert(index, [ arrayToYArray(value) ]);
           else if (value instanceof Object)
-          {
-            sharedType.insert(0, [
-              ...left,
-              objectToYMap(value),
-              ...right
-            ]);
-          }
+            sharedType.insert(index, [ objectToYMap(value) ]);
           else
-            sharedType.insert(0, [ ...left, value, ...right ]);
+            sharedType.insert(index, [ value ]);
         }
       }
       break;
@@ -169,7 +155,7 @@ export const patchSharedType = (
         sharedType.delete(property as string);
 
       else if (sharedType instanceof Y.Array)
-        sharedType.delete(property as number, 1);
+        sharedType.delete(property as number);
 
       break;
 


### PR DESCRIPTION
This is a fix to #20. As I noted [in a comment](https://github.com/joebobmiles/zustand-middleware-yjs/issues/20#issuecomment-884320795), a fix for that issue was to simply perform targeted inserts and deletes instead of trying to rewrite the whole array.