### PR TITLE
Potential Fix for Issue #41

### DIFF
--- a/src/patching.ts
+++ b/src/patching.ts
@@ -256,14 +256,19 @@ export const patchState = (oldState: any, newState: any): any =>
  * @param store The Zustand API that manages the store we want to patch.
  * @param newState The new state that the Zustand store should be patched to.
  */
-export const patchStore = <S extends State>(
+export const patchStore = <S extends unknown>(
   store: StoreApi<S>,
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   newState: any
 ): void =>
 {
+  // Clone the oldState instead of using it directly from store.getState().
+  const oldState = {
+    ...(store.getState() as Record<string, unknown>),
+  };
+
   store.setState(
-    patchState(store.getState() || {}, newState),
+    patchState(oldState, newState),
     true // Replace with the patched state.
   );
 };

--- a/src/patching.ts
+++ b/src/patching.ts
@@ -2,7 +2,7 @@ import * as Y from "yjs";
 import { ChangeType, Change, } from "./types";
 import { getChanges, } from "./diff";
 import { arrayToYArray, objectToYMap, stringToYText, } from "./mapping";
-import { State, StoreApi, } from "zustand/vanilla";
+import { StoreApi, } from "zustand/vanilla";
 
 /**
  * Diffs sharedType and newState to create a list of changes for transforming


### PR DESCRIPTION
Managed to replicate #41 and have implemented a fix.

The issue was the direct modification of the Zustand state object via pass-by-reference. The solution was to clone the state object before submitting it to the patching function. Future improvement is to submit a partial object that contains only the changed/new data instead of submitting an entirely new state object.