### PR TITLE
Fix Compatibility with Immer Middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zustand-middleware-yjs",
-  "version": "1.3.0-rc.1",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zustand-middleware-yjs",
-      "version": "1.3.0-rc.1",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "yjs": "^13.5.11",
@@ -25,6 +25,7 @@
         "@types/ws": "^7.4.7",
         "eslint": "^7.30.0",
         "husky": "^7.0.1",
+        "immer": "^10.0.2",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "react-test-renderer": "^17.0.2",
@@ -4877,6 +4878,16 @@
       "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/immer": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
+      "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
+      "devOptional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -16351,6 +16362,12 @@
       "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
       "dev": true,
       "optional": true
+    },
+    "immer": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
+      "integrity": "sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==",
+      "devOptional": true
     },
     "import-fresh": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/ws": "^7.4.7",
     "eslint": "^7.30.0",
     "husky": "^7.0.1",
+    "immer": "^10.0.2",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "react-test-renderer": "^17.0.2",


### PR DESCRIPTION
See #53.

Immer invokes `Object.freeze` on non-primitive values such as arrays and objects. This is how it achieves immutability. This presents two problems for the Yjs middleware:

1. Client updates must obey Immer's rules for modifying objects and arrays (annoying but doable).
2. State updates triggered on the client by a peer need to either:
   a. Invoke Immer's `produce` function (unfavorable coupling), or
   b. Detect if the object to modify is frozen or otherwise inextensible and treat it as immutable.