### PR TITLE
feat: allow developers to pass a transaction origin to the middleware

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@joebobmiles:registry=https://registry.npmjs.org/
+@spotter-dev:registry=https://npm.pkg.github.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zustand-middleware-yjs",
-  "version": "1.3.0-rc.1",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zustand-middleware-yjs",
-      "version": "1.3.0-rc.1",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "yjs": "^13.5.11",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zustand-middleware-yjs",
+  "name": "@spotter-dev/zustand-middleware-yjs",
   "description": "Zustand middleware for syncing state with Yjs.",
   "license": "MIT",
   "keywords": [
@@ -17,13 +17,13 @@
     "shared-editing",
     "realtime"
   ],
-  "homepage": "https://github.com/joebobmiles/zustand-middleware-yjs",
+  "homepage": "https://github.com/walfly/zustand-middleware-yjs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/joebobmiles/zustand-middleware-yjs"
+    "url": "https://github.com/walfly/zustand-middleware-yjs"
   },
   "bugs": {
-    "url": "https://github.com/joebobmiles/zustand-middleware-yjs/issues"
+    "url": "https://github.com/walfly/zustand-middleware-yjs/issues"
   },
   "author": {
     "name": "Joseph R Miles",
@@ -42,8 +42,7 @@
     "types": "./dist/index.d.ts"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
+    "registry": "https://npm.pkg.github.com"
   },
   "scripts": {
     "test": "jest",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -452,6 +452,94 @@ describe("Yjs middleware", () =>
     ]);
   });
 
+  it("passes the optional string transactionOrigin to document.transact calls", () =>
+  {
+    const ORIGIN_NAME = 'new-transaction-origin';
+    type Store =
+    {
+      count: number,
+      increment: () => void,
+    };
+
+    const doc1 = new Y.Doc();
+
+    let receivedOrigin: any;
+
+    doc1.on("update", (update: any, origin: any) =>
+    {
+      receivedOrigin = origin
+    });
+
+
+    const storeName = "store";
+
+    const { "getState": getStateA, } =
+      createVanilla<Store>(yjs(
+        doc1,
+        storeName,
+        (set) =>
+          ({
+            "count": 0,
+            "increment": () =>
+              set((state) =>
+                ({ "count": state.count + 1, })),
+          }),
+          ORIGIN_NAME
+      ));
+
+    expect(getStateA().count).toBe(0);
+
+    getStateA().increment();
+
+    expect(getStateA().count).toBe(1);
+    expect(receivedOrigin).toBe(ORIGIN_NAME)
+  })
+
+  it("passes the optional object to document.transact calls", () =>
+    {
+      const ORIGIN = {
+        name: 'Person 1',
+      };
+      type Store =
+      {
+        count: number,
+        increment: () => void,
+      };
+  
+      const doc1 = new Y.Doc();
+  
+      let receivedOrigin: any;
+  
+      doc1.on("update", (update: any, origin: any) =>
+      {
+        receivedOrigin = origin;
+      });
+  
+  
+      const storeName = "store";
+  
+      const { "getState": getStateA, } =
+        createVanilla<Store>(yjs(
+          doc1,
+          storeName,
+          (set) =>
+            ({
+              "count": 0,
+              "increment": () =>
+                set((state) =>
+                  ({ "count": state.count + 1, })),
+            }),
+            ORIGIN
+        ));
+  
+      expect(getStateA().count).toBe(0);
+  
+      getStateA().increment();
+  
+      expect(getStateA().count).toBe(1);
+      expect(receivedOrigin.name).toBe(ORIGIN.name)
+    })
+
   describe("When adding consecutive entries into arrays", () =>
   {
     it("Does not throw when inserting multiple scalars into arrays.", () =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,15 @@ type Yjs = <
 >(
   doc: Y.Doc,
   name: string,
-  f: StateCreator<T, Mps, Mcs>
+  f: StateCreator<T, Mps, Mcs>,
+  transactionOrigin?: any
 ) => StateCreator<T, Mps, Mcs>;
 
 type YjsImpl = <T extends unknown>(
   doc: Y.Doc,
   name: string,
-  config: StateCreator<T, [], []>
+  config: StateCreator<T, [], []>,
+  transactionOrigin?: any
 ) => StateCreator<T, [], []>;
 
 
@@ -46,12 +48,12 @@ type YjsImpl = <T extends unknown>(
 const yjs: YjsImpl = <S extends unknown>(
   doc: Y.Doc,
   name: string,
-  config: StateCreator<S>
+  config: StateCreator<S>,
+  transactionOrigin?: any
 ): StateCreator<S> =>
 {
   // The root Y.Map that the store is written and read from.
   const map: Y.Map<any> = doc.getMap(name);
-
   // Augment the store.
   return (set, get, api) =>
   {
@@ -68,7 +70,7 @@ const yjs: YjsImpl = <S extends unknown>(
       {
         set(partial, replace);
         doc.transact(() =>
-          patchSharedType(map, get()));
+          patchSharedType(map, get()), transactionOrigin);
       },
       get,
       {
@@ -78,7 +80,7 @@ const yjs: YjsImpl = <S extends unknown>(
         {
           api.setState(partial, replace);
           doc.transact(() =>
-            patchSharedType(map, api.getState()));
+            patchSharedType(map, api.getState()), transactionOrigin);
         },
       }
     );


### PR DESCRIPTION
I didn't see a contributor readme anywhere, so let me know if there are any changes you would like me to make to this pr.

The goal of this pr is to allow developers to pass an origin value to the middleware so that they can distinguish updates coming from the store in any event handlers they have set up.